### PR TITLE
Add delete and update api for workspaces

### DIFF
--- a/pkg/app/repository/workspace.go
+++ b/pkg/app/repository/workspace.go
@@ -8,4 +8,5 @@ import (
 type Workspace interface {
 	List(ctx context.Context) (*[]*workspace.Workspace, error)
 	Create(ctx context.Context, title string) (*workspace.Workspace, error)
+	Update(ctx context.Context, id int, title string) (*workspace.Workspace, error)
 }

--- a/pkg/app/repository/workspace.go
+++ b/pkg/app/repository/workspace.go
@@ -9,4 +9,5 @@ type Workspace interface {
 	List(ctx context.Context) (*[]*workspace.Workspace, error)
 	Create(ctx context.Context, title string) (*workspace.Workspace, error)
 	Update(ctx context.Context, id int, title string) (*workspace.Workspace, error)
+	Delete(ctx context.Context, id int) error
 }

--- a/pkg/app/workspaces/delete.go
+++ b/pkg/app/workspaces/delete.go
@@ -1,0 +1,28 @@
+package workspaces
+
+import (
+	"context"
+	"drello-api/pkg/app/repository"
+	"drello-api/pkg/domain/workspace"
+)
+
+func Delete(ctx context.Context, workspaceRepo repository.Workspace, input *DeleteInput) error {
+	err := workspaceRepo.Delete(ctx, input.id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type DeleteInput struct {
+	id int
+}
+
+func NewDeleteInput(id int) *DeleteInput {
+	return &DeleteInput{id: id}
+}
+
+type DeleteOutput struct {
+	Workspace workspace.Workspace
+}

--- a/pkg/app/workspaces/update.go
+++ b/pkg/app/workspaces/update.go
@@ -1,0 +1,25 @@
+package workspaces
+
+import (
+	"context"
+	"drello-api/pkg/app/repository"
+	"drello-api/pkg/domain/workspace"
+)
+
+func Update(ctx context.Context, workspaceRepo repository.Workspace, input *UpdateInput) (*UpdateOutput, error) {
+	wdomain, err := workspaceRepo.Update(ctx, input.ID, input.Title)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UpdateOutput{Workspace: *wdomain}, nil
+}
+
+type UpdateInput struct {
+	ID    int
+	Title string
+}
+
+type UpdateOutput struct {
+	Workspace workspace.Workspace
+}

--- a/pkg/constants/url.go
+++ b/pkg/constants/url.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	Workspaces = "/workspaces/"
+)

--- a/pkg/infrastracture/datasource/workspaces.go
+++ b/pkg/infrastracture/datasource/workspaces.go
@@ -31,3 +31,12 @@ func (w Workspace) Create(ctx context.Context, title string) (*workspace.Workspa
 
 	return workspace.New(wNode.ID, wNode.Title), nil
 }
+
+func (w Workspace) Update(ctx context.Context, id int, title string) (*workspace.Workspace, error) {
+	wNode, err := mysql.Client().Workspace.UpdateOneID(id).SetTitle(title).Save(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed querying user: %w", err)
+	}
+
+	return workspace.New(wNode.ID, wNode.Title), nil
+}

--- a/pkg/infrastracture/datasource/workspaces.go
+++ b/pkg/infrastracture/datasource/workspaces.go
@@ -40,3 +40,12 @@ func (w Workspace) Update(ctx context.Context, id int, title string) (*workspace
 
 	return workspace.New(wNode.ID, wNode.Title), nil
 }
+
+func (w Workspace) Delete(ctx context.Context, id int) error {
+	err := mysql.Client().Workspace.DeleteOneID(id).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed querying user: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/presentation/rest/route.go
+++ b/pkg/presentation/rest/route.go
@@ -9,6 +9,6 @@ import (
 func HandleRequests() {
 	fmt.Println("Listening on http://127.0.0.1:8080")
 
-	http.HandleFunc("/workspaces", Workspaces)
+	http.HandleFunc("/workspaces/", Workspaces)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/pkg/presentation/rest/route.go
+++ b/pkg/presentation/rest/route.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"drello-api/pkg/constants"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,6 +10,6 @@ import (
 func HandleRequests() {
 	fmt.Println("Listening on http://127.0.0.1:8080")
 
-	http.HandleFunc("/workspaces/", Workspaces)
+	http.HandleFunc(constants.Workspaces, Workspaces)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/pkg/presentation/rest/workspaces.go
+++ b/pkg/presentation/rest/workspaces.go
@@ -34,6 +34,8 @@ func Workspaces(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			fmt.Println(err)
 		}
+
+		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
 
 	case http.MethodPatch:

--- a/pkg/presentation/rest/workspaces.go
+++ b/pkg/presentation/rest/workspaces.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func Workspaces(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func Workspaces(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
 
 	case http.MethodPatch:
-		id, err := strconv.Atoi(r.FormValue("id"))
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/workspaces/"))
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/pkg/presentation/rest/workspaces.go
+++ b/pkg/presentation/rest/workspaces.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"drello-api/pkg/app/workspaces"
+	"drello-api/pkg/constants"
 	"drello-api/pkg/infrastracture/datasource"
 	"encoding/json"
 	"fmt"
@@ -36,7 +37,7 @@ func Workspaces(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
 
 	case http.MethodPatch:
-		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/workspaces/"))
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, constants.Workspaces))
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/pkg/presentation/rest/workspaces.go
+++ b/pkg/presentation/rest/workspaces.go
@@ -48,6 +48,19 @@ func Workspaces(w http.ResponseWriter, r *http.Request) {
 		}
 
 		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
+
+	case http.MethodDelete:
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, constants.Workspaces))
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		err = workspaces.Delete(r.Context(), datasource.Workspace{}, workspaces.NewDeleteInput(id))
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/pkg/presentation/rest/workspaces.go
+++ b/pkg/presentation/rest/workspaces.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 func Workspaces(w http.ResponseWriter, r *http.Request) {
@@ -31,6 +32,19 @@ func Workspaces(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			fmt.Println(err)
 		}
+		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
+
+	case http.MethodPatch:
+		id, err := strconv.Atoi(r.FormValue("id"))
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		output, err := workspaces.Update(r.Context(), datasource.Workspace{}, &workspaces.UpdateInput{ID: id, Title: r.FormValue("title")})
+		if err != nil {
+			fmt.Println(err)
+		}
+
 		json.NewEncoder(w).Encode(resWorkspace{ID: output.Workspace.ID(), Title: output.Workspace.Title()})
 	}
 }


### PR DESCRIPTION
Added delete and update API for workspaces.

Now you can use DELETE and PATCH requests to update or delete workspace data.

Try with this following paths.
- DELETE `/workspaces/:id`
- PATCH `/workspaces/:id`

I'll work on error handling and logging as a different issue ([link](https://github.com/setunas/drello-api/issues/21)) later. 