### PR TITLE
Add docker-compose for MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  mariadb:
+    image: mariadb:10.6.4
+    environment:
+      - MARIADB_ROOT_PASSWORD=password
+    ports:
+      - "4306:3306"
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+volumes:
+  mariadb-data: {}

--- a/pkg/infrastracture/mysql/main.go
+++ b/pkg/infrastracture/mysql/main.go
@@ -11,7 +11,7 @@ import (
 var client *ent.Client
 
 func Open() (*ent.Client, error) {
-	drv, err := sql.Open("mysql", "root@tcp(127.0.0.1:3306)/drello-dev")
+	drv, err := sql.Open("mysql", "root:password@tcp(127.0.0.1:4306)/drello-dev")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added a docker-compose .yml.
Changed DB from MySQL to MariaDB due to the problem with M1 mac.

You can set up MariaDB just with the command `docker compose up` at the root directory of the project.